### PR TITLE
fix: Update lodash to 4.17.21 to address CVE-2025-67890

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "0.21.0",
-        "lodash": "4.17.20",
+        "lodash": "^4.17.21",
         "moment": "2.29.1",
         "semver": "7.5.1",
         "tar": "6.1.6"
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "vulnerable-test-app",
-  "version": "1.0.0",
+  "author": "AutoPatch CLI Test",
+  "dependencies": {
+    "axios": "0.21.0",
+    "lodash": "^4.17.21",
+    "moment": "2.29.1",
+    "semver": "7.5.1",
+    "tar": "6.1.6"
+  },
   "description": "A test application with vulnerable dependencies for testing AutoPatch CLI",
-  "main": "index.js",
-  "scripts": {
-    "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "devDependencies": {
+    "braces": "3.0.2",
+    "ini": "1.3.5",
+    "micromatch": "4.0.7",
+    "netmask": "1.0.6"
   },
   "keywords": [
     "test",
     "vulnerability",
     "autopatch"
   ],
-  "author": "AutoPatch CLI Test",
   "license": "MIT",
-  "dependencies": {
-    "axios": "0.21.0",
-    "lodash": "4.17.20",
-    "moment": "2.29.1",
-    "semver": "7.5.1",
-    "tar": "6.1.6"
+  "main": "index.js",
+  "name": "vulnerable-test-app",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "devDependencies": {
-    "braces": "3.0.2",
-    "micromatch": "4.0.7",
-    "ini": "1.3.5",
-    "netmask": "1.0.6"
-  }
+  "version": "1.0.0"
 }


### PR DESCRIPTION
This PR updates lodash to version 4.17.21 to address CVE-2025-67890.

**Vulnerability Details:**
- CVE: CVE-2025-67890
- Severity: Medium
- Package: lodash
- Affected versions: <=4.17.20
- Fixed version: 4.17.21

**Description:**
Prototype pollution vulnerability in lodash.

**Changes Made:**
- Updated lodash from affected version to 4.17.21

This patch was automatically generated by AutoPatch CLI.
