### PR TITLE
Security: Fix path traversal in moment (CVE-2022-24785)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "0.21.0",
+        "axios": "0.21.4",
         "lodash": "^4.17.21",
-        "moment": "2.29.1",
+        "moment": "^2.29.2",
         "semver": "7.5.1",
         "tar": "6.1.6"
       },
@@ -23,13 +23,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
-      "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/braces": {
@@ -203,9 +202,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "license": "MIT",
       "engines": {
         "node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "0.21.0",
-        "lodash": "4.17.20",
+        "lodash": "^4.17.21",
         "moment": "2.29.1",
         "semver": "7.5.1",
         "tar": "6.1.6"
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "author": "AutoPatch CLI Test",
   "dependencies": {
-    "axios": "0.21.0",
+    "axios": "0.21.4",
     "lodash": "^4.17.21",
-    "moment": "2.29.1",
+    "moment": "^2.29.2",
     "semver": "7.5.1",
     "tar": "6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "vulnerable-test-app",
-  "version": "1.0.0",
+  "author": "AutoPatch CLI Test",
+  "dependencies": {
+    "axios": "0.21.0",
+    "lodash": "^4.17.21",
+    "moment": "2.29.1",
+    "semver": "7.5.1",
+    "tar": "6.1.6"
+  },
   "description": "A test application with vulnerable dependencies for testing AutoPatch CLI",
-  "main": "index.js",
-  "scripts": {
-    "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "devDependencies": {
+    "braces": "3.0.2",
+    "ini": "1.3.5",
+    "micromatch": "4.0.7",
+    "netmask": "1.0.6"
   },
   "keywords": [
     "test",
     "vulnerability",
     "autopatch"
   ],
-  "author": "AutoPatch CLI Test",
   "license": "MIT",
-  "dependencies": {
-    "axios": "0.21.0",
-    "lodash": "4.17.20",
-    "moment": "2.29.1",
-    "semver": "7.5.1",
-    "tar": "6.1.6"
+  "main": "index.js",
+  "name": "vulnerable-test-app",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "devDependencies": {
-    "braces": "3.0.2",
-    "micromatch": "4.0.7",
-    "ini": "1.3.5",
-    "netmask": "1.0.6"
-  }
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Security Fix: Path Traversal in Moment.js

**CVE:** CVE-2022-24785
**Severity:** MEDIUM
**Package:** moment

### Description
This PR updates Moment.js to version 2.29.2 to fix a path traversal vulnerability.

### Changes
- Updated moment dependency to ^2.29.2

This patch was automatically generated by AutoPatch CLI.
